### PR TITLE
add file watcher to handle changes introduced by git commands

### DIFF
--- a/lua/sync-remote/init.lua
+++ b/lua/sync-remote/init.lua
@@ -33,10 +33,7 @@ end
 
 local function isConfigFileValid()
 	if next(config) == nil then
-		vim.notify(
-			".nvim/config.txt file not found in current working directory. If the current working directory is the local folder you wish to sync with remote, then you can add the config file here: "
-				.. cwd
-		)
+		vim.notify("Please run SyncRemoteStart to load config file" .. cwd)
 		return false
 	end
 end

--- a/lua/sync-remote/init.lua
+++ b/lua/sync-remote/init.lua
@@ -2,7 +2,8 @@ local M = {}
 local config = {}
 local cwd = vim.loop.cwd()
 
-local function loadConfig()
+function M.loadConfig()
+	vim.notify("Initializing sync-remote")
 	local configFilePath = cwd .. "/.nvim/config.txt"
 	local file = io.open(configFilePath, "r")
 
@@ -16,7 +17,17 @@ local function loadConfig()
 			end
 		end
 		file:close()
-		config.local_root = config.local_root:gsub("~", os.getenv("HOME"))
+		if next(config) == nil then
+			vim.notify(".nvim/config.txt file is empty!")
+		else
+			config.local_root = config.local_root:gsub("~", os.getenv("HOME"))
+			vim.notify("Completed initializing!")
+		end
+	else
+		vim.notify(
+			".nvim/config.txt file not found in current working directory. If the current working directory is the local folder you wish to sync with remote, then you can add the config file here: "
+				.. cwd
+		)
 	end
 end
 
@@ -31,12 +42,9 @@ local function isConfigFileValid()
 end
 
 function M.setup()
-	loadConfig()
-
+	vim.cmd([[command! SyncRemoteStart lua require('sync-remote').loadConfig()]])
 	vim.cmd([[command! SyncRemoteFileUp lua require('sync-remote').syncRemoteFileUp()]])
-
 	vim.cmd([[command! SyncRemoteUp lua require('sync-remote').syncRemoteUp()]])
-
 	vim.cmd([[command! SyncRemoteDown lua require('sync-remote').syncRemoteDown()]])
 end
 

--- a/lua/sync-remote/scripts/watcher.sh
+++ b/lua/sync-remote/scripts/watcher.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+remote_root=$1
+echo "executing" >>~/debug.log
+for path in ${@:2}; do
+	full_path=${WATCHMAN_ROOT}/$path
+	if [ -e "$full_path" ] && [[ "$full_path" != *".git"* ]]; then
+		echo "rsync -rvzu --no-whole-file ${WATCHMAN_ROOT}/$path $remote_root/$path" >>~/debug.log
+		rsync -rvzu --no-whole-file ${WATCHMAN_ROOT}/$path $remote_root/$path
+	fi
+done


### PR DESCRIPTION
Git commands like checkout and pull change the content of local directory. In order to capture those changes, a file watcher has been used. The watcher will sync the changed files with remote when it gets triggered.